### PR TITLE
Proper monkey patching

### DIFF
--- a/lib/abbrev.js
+++ b/lib/abbrev.js
@@ -4,8 +4,15 @@ module.exports = exports = abbrev.abbrev = abbrev
 abbrev.monkeyPatch = monkeyPatch
 
 function monkeyPatch () {
-  Array.prototype.abbrev = function () { return abbrev(this) }
-  Object.prototype.abbrev = function () { return abbrev(Object.keys(this)) }
+  Object.defineProperty(Array.prototype, 'abbrev', {
+      value: function () { return abbrev(this) },
+      enumerable: false
+  })
+
+  Object.defineProperty(Object.prototype, 'abbrev', {
+      value: function () { return abbrev(Object.keys(this)) },
+      enumerable: false
+  })
 }
 
 function abbrev (list) {
@@ -32,8 +39,7 @@ function abbrev (list) {
       var curChar = current.charAt(j)
       nextMatches = nextMatches && curChar === next.charAt(j)
       prevMatches = prevMatches && curChar === prev.charAt(j)
-      if (nextMatches || prevMatches) continue
-      else {
+      if (!nextMatches && !prevMatches) {
         j ++
         break
       }


### PR DESCRIPTION
The actual monkey patching method makes `abbrev` properties enumerable:

``` js
require( 'abbrev' ).monkeyPatch();

var a = [ 'foo', 'bar' ], i;

for ( i in a )
    console.log( i );

/*
   Output:
    0
    1
    abbrev
*/
```

With my patch, the `abbrev` property is not enumerable anymore:

``` js
/*
   Output:
    0
    1
*/
```

I also simplified an `if/else` instruction:

``` js
for ( /* … */ ) {
  // …
  if ( something ) continue;
  else do_something_else;
}
```

is the same as:

``` js
for ( /* … */ ) {
  // …
  if ( !something ) do_something_else;
}
```
