### PR TITLE
support for use_strict

### DIFF
--- a/lib/abbrev.js
+++ b/lib/abbrev.js
@@ -1,4 +1,3 @@
-
 module.exports = exports = abbrev.abbrev = abbrev
 
 abbrev.monkeyPatch = monkeyPatch
@@ -69,7 +68,7 @@ var assert = require("assert")
 var util = require("util")
 
 console.log("running tests")
-function test (list, expect) {
+var test = function(list, expect) {
   var actual = abbrev(list)
   assert.deepEqual(actual, expect,
     "abbrev("+util.inspect(list)+") === " + util.inspect(expect) + "\n"+


### PR DESCRIPTION
I would like to use abbrev with node --use_strict.
