### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/abbrev.js
+++ b/abbrev.js
@@ -48,7 +48,7 @@ function abbrev (list) {
       abbrevs[current] = current
       continue
     }
-    for (var a = current.substr(0, j) ; j <= cl ; j ++) {
+    for (var a = current.slice(0, j) ; j <= cl ; j ++) {
       abbrevs[a] = current
       a += current.charAt(j)
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.