### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ function abbrev (...args) {
       abbrevs[current] = current
       continue
     }
-    for (let a = current.substr(0, j); j <= cl; j++) {
+    for (let a = current.slice(0, j); j <= cl; j++) {
       abbrevs[a] = current
       a += current.charAt(j)
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

This is a new PR as I had to redo my commit because I deleted the branch after the old PR (#34) was closed