### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ function abbrev (...args) {
       abbrevs[current] = current
       continue
     }
-    for (let a = current.substr(0, j); j <= cl; j++) {
+    for (let a = current.slice(0, j); j <= cl; j++) {
       abbrevs[a] = current
       a += current.charAt(j)
     }


### PR DESCRIPTION
Closes #38 
